### PR TITLE
fix: rename scroll-tech to wemixkanvas

### DIFF
--- a/trie/zk_trie_impl_test.go
+++ b/trie/zk_trie_impl_test.go
@@ -4,8 +4,8 @@ import (
 	"math/big"
 	"testing"
 
-	zkt "github.com/scroll-tech/zktrie/types"
 	"github.com/stretchr/testify/assert"
+	zkt "github.com/wemixkanvas/zktrie/types"
 )
 
 var lcEff *big.Int


### PR DESCRIPTION
This is a missing change from previous commit.